### PR TITLE
feat(quests): add archive system for manual quest completion

### DIFF
--- a/shared/types.ts
+++ b/shared/types.ts
@@ -392,7 +392,7 @@ export interface AchievementMeta {
 // QUESTS (Cross-repo goals with phased execution)
 // ═══════════════════════════════════════════════════════════════════════════
 
-export type QuestStatus = 'active' | 'completed' | 'paused'
+export type QuestStatus = 'active' | 'completed' | 'paused' | 'archived'
 
 export type QuestPhaseStatus =
   | 'pending'
@@ -401,6 +401,7 @@ export type QuestPhaseStatus =
   | 'retrying'
   | 'completed'
   | 'failed'
+  | 'skipped'
 
 export interface QuestPhase {
   id: string
@@ -432,6 +433,9 @@ export interface Quest {
   commits?: number             // Total commits made
   testsRun?: number            // Total test runs
   toolsUsed?: Record<string, number>  // Tool name -> count
+  // Archive metadata
+  archivedAt?: number          // When archive computation completed
+  archiveSource?: 'computed' | 'tracked'  // How stats were derived
 }
 
 export type QuestEventType =

--- a/src/hooks/useQuests.ts
+++ b/src/hooks/useQuests.ts
@@ -17,6 +17,20 @@ export async function updateQuestStatus(questId: string, status: QuestStatus): P
   }
 }
 
+// Archive quest (compute stats from event history)
+export async function archiveQuest(questId: string): Promise<{ ok: boolean; data?: Quest; error?: string }> {
+  try {
+    const res = await fetch(`${API_URL}/api/quests/${encodeURIComponent(questId)}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'archive' }),
+    })
+    return await res.json()
+  } catch {
+    return { ok: false, error: 'Network error' }
+  }
+}
+
 export function useQuests() {
   const [quests, setQuests] = useState<Quest[]>([])
   const [loading, setLoading] = useState(true)


### PR DESCRIPTION
## Summary
- Add two-stage completion flow for quests: Complete → Archive
- Archive computes stats retroactively from event history
- Incomplete phases marked as 'skipped' on archive
- Purple theme for archived quests vs green for completed

## Changes
- Add 'archived' status and 'skipped' phase status to types
- Add `archiveQuest()` function to compute stats from events
- Add Archive button for completed quests in UI
- Shows "computed" indicator when stats derived from history

## Test plan
- [x] Archive quest with all-pending phases → phases become 'skipped'
- [x] Archive quest with completed phases → completed phases preserved
- [x] Stats computed correctly (XP, commits, tests, tools)
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)