### PR TITLE
fix(server): capture terminal content to actual bottom of scrollback

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1107,8 +1107,9 @@ async function captureTerminal(target: string, fullScrollback = false): Promise<
     // Flags:
     // -p: print to stdout
     // -J: join wrapped lines (cleaner parsing)
-    // -S -50: capture last 50 lines (default) or -S - -E - for full scrollback
-    const scrollFlags = fullScrollback ? '-S - -E -' : '-S -150'
+    // -e: include escape sequences (ANSI colors)
+    // -S -150 -E -: capture last 150 lines to end of scrollback (ensures we get the bottom)
+    const scrollFlags = fullScrollback ? '-S - -E -' : '-S -150 -E -'
     const { stdout } = await execAsync(
       `tmux capture-pane -p -J -e -t "${target}" ${scrollFlags}`,
       { timeout: 1000 }


### PR DESCRIPTION
## Summary
- Add `-E -` flag to `tmux capture-pane` to ensure we capture to the end of the scrollback buffer
- Without this flag, capture only goes to the cursor position, missing content when the cursor isn't at the bottom
- Fixes issue where terminal display showed stale content instead of the most recent output

## Test plan
- [ ] Start server and verify terminal content shows the actual bottom of Claude output
- [ ] Scroll up in tmux pane and verify UI still shows latest content

🤖 Generated with [Claude Code](https://claude.com/claude-code)