### PR TITLE
fix(ui): correct header title and subtitle order

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -50,8 +50,8 @@ export function Layout() {
                 <span className="text-lg">⚔</span>
               </div>
               <div>
-                <h1 className="font-bold text-rpg-text leading-tight">tmux tracker</h1>
-                <p className="text-[10px] text-rpg-text-dim tracking-wide">CLAUDE COMPANION</p>
+                <h1 className="font-bold text-rpg-text leading-tight">claude-rpg</h1>
+                <p className="text-[10px] text-rpg-text-dim tracking-wide">TMUX TRACKER</p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary

- Fixes header branding from "tmux tracker / CLAUDE COMPANION" to "claude-rpg / TMUX TRACKER"

Closes #186

## Test plan

- [ ] Verify header displays "claude-rpg" as main title
- [ ] Verify "TMUX TRACKER" appears as subtitle

🤖 Generated with [Claude Code](https://claude.com/claude-code)