### PR TITLE
fix(terminal): disable diffs until per-client tracking

### DIFF
--- a/server-v2/index.ts
+++ b/server-v2/index.ts
@@ -136,7 +136,9 @@ async function main() {
             const diff = generateDiff(lastContent, pane.terminalContent)
             const fullSize = JSON.stringify(pane.terminalContent).length
 
-            if (diff.estimatedSize < fullSize * 0.8) {
+            // TODO: Diffs require per-client tracking to work correctly
+            // Currently disabled (threshold 0) until we track what each client has received
+            if (diff.estimatedSize < fullSize * 0) {
               // Diff is smaller - send it
               broadcast({
                 type: 'terminal_diff',


### PR DESCRIPTION
## Summary

Fixes terminal display not showing latest content after reconnection.

## Problem

The incremental diff system uses a global `lastSentContent` cache to track what was last sent. When clients reconnect, they receive diffs based on content they never received, resulting in corrupted/stale terminal display.

## Solution

Temporarily disabled diffs by setting threshold to 0 (always send full content). The diff infrastructure remains for future implementation with per-client state tracking.

## Test plan

- [x] Service restarts successfully
- [x] Terminal shows latest content after refresh
- [x] No stale content after page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)