### PR TITLE
fix(notifications): handle unsupported Notification constructor

### DIFF
--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -42,17 +42,24 @@ export function useNotifications(): UseNotificationsResult {
       return null
     }
 
-    const notification = new Notification(title, {
-      icon: DEFAULT_ICON,
-      ...options,
-    })
+    try {
+      const notification = new Notification(title, {
+        icon: DEFAULT_ICON,
+        ...options,
+      })
 
-    notification.onclick = () => {
-      window.focus()
-      notification.close()
+      notification.onclick = () => {
+        window.focus()
+        notification.close()
+      }
+
+      return notification
+    } catch {
+      // iOS Safari and some browsers don't support direct Notification construction
+      // They require ServiceWorker.showNotification() instead
+      console.warn('Browser notifications not supported, use ServiceWorker instead')
+      return null
     }
-
-    return notification
   }, [permission])
 
   return { permission, requestPermission, notify }


### PR DESCRIPTION
## Summary

Fixes app crash on iOS Safari and browsers that don't support direct `new Notification()`.

## Problem

iOS Safari has `Notification` in window but throws "Illegal constructor" when trying to use it directly. These browsers require `ServiceWorker.showNotification()` instead.

## Solution

Wrap `new Notification()` in try-catch to gracefully handle unsupported browsers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)